### PR TITLE
chore: update cypress workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Install dependencies, cache them correctly
       # and run all Cypress tests
       - name: cypress run
@@ -20,14 +20,14 @@ jobs:
           wait-on-timeout: 180
 
       - name: upload screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
       - name: upload videos
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-videos


### PR DESCRIPTION
This PR updates the version of the workflows that are used to remove the deprecation warning.

closes #12 