### PR TITLE
Update Readme with deployement link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Explaining Image Privacy - Demo App
+# Explaining Image Privacy - App
 
 Explaining Image Privacy using a Web interface.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-# explaining-image-privacy-app
+# Explaining Image Privacy - Demo App
 
 Explaining Image Privacy using a Web interface.
+
+🔮 Click on the badge bellow to see the app live ✨
+
+[![Live deploy](https://www.netlify.com/v3/img/components/netlify-color-bg.svg)](https://fabulous-genie-8afcaf.netlify.app/)
 
 ## Installation
 
 Make sure you have `yarn` installed. You can check by running `yarn --version`.
 You can find yarn installation instructions [on the yarn website](https://yarnpkg.com/getting-started/install).
 
-You may also need `nodejs`. It is recommended to install Node using `nvm` which is the *node version manager* so you can switch between node version easily.
+You may also need `nodejs`. It is recommended to install Node using `nvm` which is the _node version manager_ so you can switch between node version easily.
 You can find installation information [on the nvm github repo](https://github.com/nvm-sh/nvm#installing-and-updating).
 
 Before running the app you need to create a few environnement files:


### PR DESCRIPTION
This PR updates the readme to include a link to the live version of the app on netlify (see rendered readme bellow)

<img width="1215" alt="Screenshot 2022-10-31 at 11 35 01" src="https://user-images.githubusercontent.com/39373170/198989031-f1a56663-5c59-4104-9dff-9a5bf3d040fc.png">

closes #4
