### PR TITLE
feat: remove the back button

### DIFF
--- a/public/data/4321643535_615b796e55_z.csv
+++ b/public/data/4321643535_615b796e55_z.csv
@@ -1,4 +1,4 @@
-keyword,coef
+keyword,confidence
 group,0.99
 people,0.99
 adult,0.98

--- a/public/data/4324929145_fab263ee8a_z.csv
+++ b/public/data/4324929145_fab263ee8a_z.csv
@@ -1,4 +1,4 @@
-keyword,coef
+keyword,confidence
 light,1.00
 art,0.99
 room,0.99

--- a/public/data/4345523165_cc0fc43748_z.csv
+++ b/public/data/4345523165_cc0fc43748_z.csv
@@ -1,4 +1,4 @@
-keyword,coef
+keyword,confidence
 abstract,0.99
 art,0.99
 architecture,0.98

--- a/public/data/4349185271_ae909d657f_z.csv
+++ b/public/data/4349185271_ae909d657f_z.csv
@@ -1,4 +1,4 @@
-keyword,coef
+keyword,confidence
 snow,1.00
 winter,1.00
 snowstorm,0.99

--- a/public/data/4351384588_22294270f8_z.csv
+++ b/public/data/4351384588_22294270f8_z.csv
@@ -1,4 +1,4 @@
-keyword,coef
+keyword,confidence
 people,0.98
 war,0.98
 soldier,0.98

--- a/public/data/4366774287_bf240d764d_z.csv
+++ b/public/data/4366774287_bf240d764d_z.csv
@@ -1,4 +1,4 @@
-keyword,coef
+keyword,confidence
 shining,1.00
 accessory,0.99
 chain,0.99

--- a/public/data/4367495664_10888e0cea_z.csv
+++ b/public/data/4367495664_10888e0cea_z.csv
@@ -1,4 +1,4 @@
-keyword,coef
+keyword,confidence
 flame,1.00
 indoors,0.99
 portrait,0.99

--- a/public/data/4376006758_92098a3801_z.csv
+++ b/public/data/4376006758_92098a3801_z.csv
@@ -1,4 +1,4 @@
-keyword,coef
+keyword,confidence
 portrait,1.00
 man,0.99
 people,0.99

--- a/public/data/4377731375_716bd4714d_z.csv
+++ b/public/data/4377731375_716bd4714d_z.csv
@@ -1,4 +1,4 @@
-keyword,coef
+keyword,confidence
 portrait,1.00
 people,0.99
 man,0.97

--- a/public/data/4377764972_bb8a13251b_z.csv
+++ b/public/data/4377764972_bb8a13251b_z.csv
@@ -1,4 +1,4 @@
-keyword,coef
+keyword,confidence
 child,0.99
 girl,0.98
 people,0.98

--- a/src/components/HistogramBar.tsx
+++ b/src/components/HistogramBar.tsx
@@ -30,10 +30,10 @@ const HistogramBar: FC<Props> = ({ data }) => (
   >
     <CartesianGrid strokeDasharray="3 3" />
     <XAxis dataKey="keyword" />
-    <YAxis />
+    <YAxis domain={[0, 1]} />
     <Tooltip />
     <Legend />
-    <Bar dataKey="coef" fill="#82ca9d" />
+    <Bar dataKey="confidence" fill="#82ca9d" />
   </BarChart>
 );
 

--- a/src/pages/DynamicLocalPage.tsx
+++ b/src/pages/DynamicLocalPage.tsx
@@ -6,7 +6,6 @@ import { Box, Container, Text } from '@chakra-ui/react';
 import DisplayImage from '../components/DisplayImage';
 import DynamicLocal from '../components/DynamicLocal';
 import ImageSelect from '../components/ImageSelect';
-import BackButton from '../components/common/BackButton';
 import imageLabels from '../data/image_label.json';
 import { CategoryData } from '../types';
 import { fetchImageData, splitKeywordsInCategories } from '../utils/imageData';
@@ -30,7 +29,6 @@ const DynamicLocalPage: FC = () => {
   return (
     <Container>
       <Box>
-        <BackButton />
         <Text>{t('Select an image')}</Text>
         <ImageSelect
           imageId={imageId}

--- a/src/pages/DynamicLocalPage.tsx
+++ b/src/pages/DynamicLocalPage.tsx
@@ -1,43 +1,49 @@
 import { FC, useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 
-import { Box, Container, Text } from '@chakra-ui/react';
+import { Container } from '@chakra-ui/react';
 
 import DisplayImage from '../components/DisplayImage';
 import DynamicLocal from '../components/DynamicLocal';
-import ImageSelect from '../components/ImageSelect';
 import imageLabels from '../data/image_label.json';
 import { CategoryData } from '../types';
 import { fetchImageData, splitKeywordsInCategories } from '../utils/imageData';
 
 const DynamicLocalPage: FC = () => {
-  const { t } = useTranslation();
+  const Image1 = Object.keys(imageLabels)[1];
+  const Image2 = Object.keys(imageLabels)[3];
 
-  const defaultImage = Object.keys(imageLabels)[0];
-  const [imageId, setImageId] = useState<string>(Object.keys(imageLabels)[0]);
-  const [imageCategories, setImageCategories] = useState<CategoryData>({});
+  const [imageId1] = useState<string>(Object.keys(imageLabels)[1]);
+  const [imageId2] = useState<string>(Object.keys(imageLabels)[3]);
+
+  const [imageCategories1, setImageCategories1] = useState<CategoryData>({});
+  const [imageCategories2, setImageCategories2] = useState<CategoryData>({});
 
   useEffect(
     () => {
-      fetchImageData(defaultImage, (imageData) =>
-        setImageCategories(splitKeywordsInCategories(imageData)),
+      fetchImageData(Image1, (imageData) =>
+        setImageCategories1(splitKeywordsInCategories(imageData)),
       );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
+
+  useEffect(
+    () => {
+      fetchImageData(Image2, (imageData) =>
+        setImageCategories2(splitKeywordsInCategories(imageData)),
+      );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
   return (
     <Container>
-      <Box>
-        <Text>{t('Select an image')}</Text>
-        <ImageSelect
-          imageId={imageId}
-          setImageId={setImageId}
-          setImageCategories={setImageCategories}
-        />
-      </Box>
-      <DisplayImage imageId={imageId} mt={2} />
-      <DynamicLocal data={imageCategories} />
+      <DisplayImage imageId={imageId1} mt={2} />
+      <DynamicLocal data={imageCategories1} />
+      <DisplayImage imageId={imageId2} mt={2} />
+      <DynamicLocal data={imageCategories2} />
     </Container>
   );
 };

--- a/src/pages/SimpleLocalPage.tsx
+++ b/src/pages/SimpleLocalPage.tsx
@@ -1,23 +1,37 @@
 import { FC, useEffect, useState } from 'react';
 
-import { Box, Container } from '@chakra-ui/react';
+import { Container } from '@chakra-ui/react';
 
 import DisplayImage from '../components/DisplayImage';
-import ImageSelect from '../components/ImageSelect';
 import SimpleLocal from '../components/SimpleLocal';
 import imageLabels from '../data/image_label.json';
 import { CategoryData } from '../types';
 import { fetchImageData, splitKeywordsInCategories } from '../utils/imageData';
 
 const SimpleLocalPage: FC = () => {
-  const defaultImage = Object.keys(imageLabels)[0];
-  const [imageId, setImageId] = useState<string>(Object.keys(imageLabels)[0]);
-  const [imageCategories, setImageCategories] = useState<CategoryData>({});
+  const Image1 = Object.keys(imageLabels)[1];
+  const Image2 = Object.keys(imageLabels)[3];
+
+  const [imageId1] = useState<string>(Object.keys(imageLabels)[1]);
+  const [imageId2] = useState<string>(Object.keys(imageLabels)[3]);
+
+  const [imageCategories1, setImageCategories1] = useState<CategoryData>({});
+  const [imageCategories2, setImageCategories2] = useState<CategoryData>({});
 
   useEffect(
     () => {
-      fetchImageData(defaultImage, (imageData) =>
-        setImageCategories(splitKeywordsInCategories(imageData)),
+      fetchImageData(Image1, (imageData) =>
+        setImageCategories1(splitKeywordsInCategories(imageData)),
+      );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  useEffect(
+    () => {
+      fetchImageData(Image2, (imageData) =>
+        setImageCategories2(splitKeywordsInCategories(imageData)),
       );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -26,15 +40,10 @@ const SimpleLocalPage: FC = () => {
 
   return (
     <Container w="100pw">
-      <Box>
-        <ImageSelect
-          imageId={imageId}
-          setImageId={setImageId}
-          setImageCategories={setImageCategories}
-        />
-      </Box>
-      <DisplayImage imageId={imageId} mt={2} />
-      <SimpleLocal data={imageCategories} />
+      <DisplayImage imageId={imageId1} mt={2} />
+      <SimpleLocal data={imageCategories1} />
+      <DisplayImage imageId={imageId2} mt={2} />
+      <SimpleLocal data={imageCategories2} />
     </Container>
   );
 };

--- a/src/pages/SimpleLocalPage.tsx
+++ b/src/pages/SimpleLocalPage.tsx
@@ -5,7 +5,6 @@ import { Box, Container } from '@chakra-ui/react';
 import DisplayImage from '../components/DisplayImage';
 import ImageSelect from '../components/ImageSelect';
 import SimpleLocal from '../components/SimpleLocal';
-import BackButton from '../components/common/BackButton';
 import imageLabels from '../data/image_label.json';
 import { CategoryData } from '../types';
 import { fetchImageData, splitKeywordsInCategories } from '../utils/imageData';
@@ -26,9 +25,8 @@ const SimpleLocalPage: FC = () => {
   );
 
   return (
-    <Container>
+    <Container w="100pw">
       <Box>
-        <BackButton />
         <ImageSelect
           imageId={imageId}
           setImageId={setImageId}

--- a/src/pages/SimpleLocalPage.tsx
+++ b/src/pages/SimpleLocalPage.tsx
@@ -39,7 +39,7 @@ const SimpleLocalPage: FC = () => {
   );
 
   return (
-    <Container w="100pw">
+    <Container w="100vw" p={3}>
       <DisplayImage imageId={imageId1} mt={2} />
       <SimpleLocal data={imageCategories1} />
       <DisplayImage imageId={imageId2} mt={2} />

--- a/src/pages/WordCloudLocalPage.tsx
+++ b/src/pages/WordCloudLocalPage.tsx
@@ -5,7 +5,6 @@ import { Box, Container } from '@chakra-ui/react';
 import DisplayImage from '../components/DisplayImage';
 import DynamicLocal from '../components/DynamicLocal';
 import ImageSelect from '../components/ImageSelect';
-import BackButton from '../components/common/BackButton';
 import imageLabels from '../data/image_label.json';
 import { CategoryData } from '../types';
 import { fetchImageData, splitKeywordsInCategories } from '../utils/imageData';
@@ -27,7 +26,6 @@ const WordCloudLocalPage: FC = () => {
   return (
     <Container>
       <Box>
-        <BackButton />
         <ImageSelect
           imageId={imageId}
           setImageId={setImageId}

--- a/src/pages/WordCloudLocalPage.tsx
+++ b/src/pages/WordCloudLocalPage.tsx
@@ -1,39 +1,49 @@
 import { FC, useEffect, useState } from 'react';
 
-import { Box, Container } from '@chakra-ui/react';
+import { Container } from '@chakra-ui/react';
 
 import DisplayImage from '../components/DisplayImage';
 import DynamicLocal from '../components/DynamicLocal';
-import ImageSelect from '../components/ImageSelect';
 import imageLabels from '../data/image_label.json';
 import { CategoryData } from '../types';
 import { fetchImageData, splitKeywordsInCategories } from '../utils/imageData';
 
 const WordCloudLocalPage: FC = () => {
-  const defaultImage = Object.keys(imageLabels)[0];
-  const [imageId, setImageId] = useState<string>(Object.keys(imageLabels)[0]);
-  const [imageCategories, setImageCategories] = useState<CategoryData>({});
+  const Image1 = Object.keys(imageLabels)[1];
+  const Image2 = Object.keys(imageLabels)[3];
+
+  const [imageId1] = useState<string>(Object.keys(imageLabels)[1]);
+  const [imageId2] = useState<string>(Object.keys(imageLabels)[3]);
+
+  const [imageCategories1, setImageCategories1] = useState<CategoryData>({});
+  const [imageCategories2, setImageCategories2] = useState<CategoryData>({});
 
   useEffect(
     () => {
-      fetchImageData(defaultImage, (imageData) =>
-        setImageCategories(splitKeywordsInCategories(imageData)),
+      fetchImageData(Image1, (imageData) =>
+        setImageCategories1(splitKeywordsInCategories(imageData)),
       );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
+
+  useEffect(
+    () => {
+      fetchImageData(Image2, (imageData) =>
+        setImageCategories2(splitKeywordsInCategories(imageData)),
+      );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
   return (
-    <Container>
-      <Box>
-        <ImageSelect
-          imageId={imageId}
-          setImageId={setImageId}
-          setImageCategories={setImageCategories}
-        />
-      </Box>
-      <DisplayImage imageId={imageId} mt={2} />
-      <DynamicLocal data={imageCategories} />
+    <Container w="100pw">
+      <DisplayImage imageId={imageId1} mt={2} />
+      <DynamicLocal data={imageCategories1} />
+      <DisplayImage imageId={imageId2} mt={2} />
+      <DynamicLocal data={imageCategories2} />
     </Container>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type BubbleCategory = {
   children: Category[];
 };
 
-export type ImageKeyword = { keyword: string; coef: number };
+export type ImageKeyword = { keyword: string; confidence: number };
 
 // My responsible chord data type
 export type ChordCategory = number[][];

--- a/src/utils/imageData.ts
+++ b/src/utils/imageData.ts
@@ -46,7 +46,7 @@ export const transformDataToBubbles = (
   const bubbles = Object.entries(imageCategories).map(([cat, keywords]) => ({
     // todo: add nice categories
     name: cat,
-    children: keywords.map((k) => ({ name: k.keyword, value: k.coef })),
+    children: keywords.map((k) => ({ name: k.keyword, value: k.confidence })),
   })) as Category[];
 
   return {


### PR DESCRIPTION
This PR adapts the interface for the test.
- It remove the navigation with the back button
- It scale the Y axes from 0 to 1 of the histogram bar
- It put 2 images one below the other

![image](https://user-images.githubusercontent.com/43374563/206003945-97ffa1b8-cde9-451f-aa74-93392bf26d8a.png)

Graph will be resize in next commit/PR

close #46 
close #36 
close #45 