### PR TITLE
feat: add accordion in wordcloud

### DIFF
--- a/src/components/WordCloudLocal.tsx
+++ b/src/components/WordCloudLocal.tsx
@@ -2,9 +2,10 @@ import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TagCloud } from 'react-tagcloud';
 
-import { Box, Container } from '@chakra-ui/react';
+import { Accordion, Box, Container, HStack } from '@chakra-ui/react';
 
 import { WordCloudKeyword } from '../types';
+import CategoryItem from './CategoryItem';
 import WordCloudLegend from './WordCloudLegend';
 import VizualisationDescription from './common/VizualisationDescription';
 
@@ -12,21 +13,41 @@ type Props = {
   data: WordCloudKeyword[];
   categories: string[];
 };
+
 const WordCloudLocal: FC<Props> = ({ data, categories }) => {
   const { t } = useTranslation();
   return (
-    <Container maxW="80vw" padding="3" centerContent gap={6}>
+    <Container maxW="100vw" padding="3" centerContent gap={6}>
       <VizualisationDescription>
         {t('WORDCLOUD_DESCRIPTION')}
       </VizualisationDescription>
-      <Box
-        as={TagCloud}
-        sx={{ textAlign: 'center' }}
-        maxSize={40}
-        minSize={10}
-        tags={data}
-      />
-      <WordCloudLegend categories={categories} />
+      <HStack spacing={2} width="100%">
+        <Box flex={2} p={1} flexDirection="column">
+          <Box
+            as={TagCloud}
+            sx={{ textAlign: 'center' }}
+            maxSize={40}
+            minSize={10}
+            tags={data}
+          />
+          <WordCloudLegend categories={categories} />
+        </Box>
+        <Box flex={1} p={1}>
+          <Accordion allowToggle>
+            {categories.map((cat) => (
+              <CategoryItem
+                key={cat}
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                title={t(`${cat.toUpperCase()}_CATEGORY`)}
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                content={t(`${cat.toUpperCase()}_CATEGORY_CONTENT`)}
+              />
+            ))}
+          </Accordion>
+        </Box>
+      </HStack>
     </Container>
   );
 };


### PR DESCRIPTION
This PR adds the accordion category to the wordcloud page.

<img width="1131" alt="Capture d’écran 2022-12-13 à 20 31 01" src="https://user-images.githubusercontent.com/39373170/207427428-436f38e5-3709-4f3d-a0b9-a7649d4bb56e.png">

closes #52 